### PR TITLE
[refactor] enhance prompting to reduce tool hallucinations

### DIFF
--- a/src/imaging_knime_to_galaxy/prompts.py
+++ b/src/imaging_knime_to_galaxy/prompts.py
@@ -138,10 +138,14 @@ The input node descriptions could be one of the following:
 
 {hits}
 
+NEVER come up with own tool IDs, content IDs or versions on your own. ONLY use the ones provided from the previously given knowledge base.
+
 - Use type: "data_input" only for a single dataset that is consumed by inputs expecting a single dataset.
 - Use type: "data_collection_input" only when any downstream input expects a collection (e.g., list or list:paired).
 - Never connect a data_input as a source if the downstream port expects a collection.
 - Never invent an "output" on data_input. If an edge would reference such an output, remove that edge and proceed only with valid edges.
+
+
 
 
 - Return a single JSON object and nothing else.


### PR DESCRIPTION
Closes #30 

I forgot to include this into the [prompts.py](src/imaging_knime_to_galaxy/prompts.py) when creating the new project structure. I did some tests whether it's possible to enhance the output quality by directly stating the prompt, that the model should not invent new tools, just by adding:

`
NEVER come up with own tool IDs, content IDs or versions on your own. ONLY use the ones provided from the previously given knowledge base.
`

and it actually worked, as can be seen in this [Notebook](https://github.com/rmassei/imaging_KNIME_to_Galaxy/blob/60a61d27b5222fda33ea74c81aa7d1e2277141ce/src/enhance_prompting.ipynb) from my very first branch.

So I think it would be a good idea to incorporate that one sentence into the prompt to hopefully get some more stable results.