### PR TITLE
update save_answer_to_file to optionally create a new output folder

### DIFF
--- a/src/imaging_knime_to_galaxy/knime_io.py
+++ b/src/imaging_knime_to_galaxy/knime_io.py
@@ -2,6 +2,7 @@ import json
 import uuid
 import zipfile
 from pathlib import Path
+import os
 
 def load_tools_metadata(path: str | Path) -> dict:
     """

--- a/src/imaging_knime_to_galaxy/knime_io.py
+++ b/src/imaging_knime_to_galaxy/knime_io.py
@@ -72,4 +72,4 @@ def replace_uuid(json_object):
 def save_answer_to_file(json_object, output_path):
     os.makedirs(os.path.dirname(output_path), exist_ok=True)
     with open(output_path, "w", encoding="utf-8") as f:
-    json.dump(json_object, f, indent=2, ensure_ascii=False)
+        json.dump(json_object, f, indent=2, ensure_ascii=False)

--- a/src/imaging_knime_to_galaxy/knime_io.py
+++ b/src/imaging_knime_to_galaxy/knime_io.py
@@ -70,6 +70,6 @@ def replace_uuid(json_object):
     return json_object
 
 def save_answer_to_file(json_object, output_path):
-    output_file = output_path
-    with open(output_file, "w", encoding="utf-8") as f:
-      json.dump(json_object, f, indent=2, ensure_ascii=False)
+    os.makedirs(os.path.dirname(output_path), exist_ok=True)
+    with open(output_path, "w", encoding="utf-8") as f:
+    json.dump(json_object, f, indent=2, ensure_ascii=False)


### PR DESCRIPTION
Hi @rmassei !
The merge was a bit too quick for me to push the new changes regarding the save_answer_to_file function with the new part of:

`os.makedirs(os.path.dirname(output_path), exist_ok=True)`

So this is the only change in this new PR / branch!
