### PR TITLE
Add report generation to the pipeline

### DIFF
--- a/notebooks/demo_notebook.ipynb
+++ b/notebooks/demo_notebook.ipynb
@@ -34,7 +34,7 @@
     "    tools_metadata_path=data_folder / \"tools_metadata.json\",\n",
     "    translation_table_path=data_folder / \"translation_table.yml\",\n",
     "    workflow_examples_yml_path=data_folder / \"workflow_translation_table.yml\",\n",
-    "    output_galaxy_workflow_path=data_folder / \"output_file\" / \"22-test2_knime2galaxy_output.ga\",\n",
+    "    output_galaxy_workflow_path=data_folder / \"output_file\" / \"knime2galaxy_output.ga\",\n",
     "    input_workflow_path =data_folder / \"input_workflows.ga\",\n",
     "    vector_store_path =data_folder/ \"vector_store.npz\",\n",
     "    \n",
@@ -44,7 +44,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6fd9e1bc-5130-429b-bb78-375e7a615a03",
+   "id": "7a6e650e-154d-405c-888f-907e2ae92fc6",
    "metadata": {},
    "outputs": [],
    "source": []

--- a/src/imaging_knime_to_galaxy/evaluation_functions.py
+++ b/src/imaging_knime_to_galaxy/evaluation_functions.py
@@ -1,0 +1,192 @@
+from pathlib import Path
+import traceback
+import re
+import pandas as pd
+import subprocess
+import os
+import json
+import yaml
+
+DATA_FOLDER = Path("../data").resolve()
+OUTPUT_FOLDER = DATA_FOLDER / "output_file_test"
+OUTPUT_FOLDER.mkdir(parents=True, exist_ok=True)
+INPUT_STEP_TYPES = {"data_input", "data_collection_input", "parameter_input"}
+
+JOB_YML = DATA_FOLDER / "job.yml"
+IMAGE = DATA_FOLDER / "image_ex.jpg"
+
+
+def generate_job_yaml(ga_path, output_path, default_file):
+    ga_path = Path(ga_path)
+    output_path = Path(output_path)
+    default_file = str(Path(default_file).resolve())
+
+    with ga_path.open("r", encoding="utf-8") as f:
+        workflow = json.load(f)
+
+    job = {}
+    for step_id, step in workflow.get("steps", {}).items():
+        if step.get("type") in INPUT_STEP_TYPES:
+            key = step.get("label") or f"input_{step_id}"
+            job[key] = {
+                "class": "File",
+                "path": default_file,
+            }
+
+    if not job:
+        raise ValueError(f"No workflow inputs found in {ga_path}")
+
+    with output_path.open("w", encoding="utf-8") as f:
+        yaml.safe_dump(job, f, sort_keys=False)
+
+    print(f"job.yml written to {output_path}")
+
+
+def add_missing_input_labels(ga_path: str | Path, output_path: str | Path | None = None):
+    ga_path = Path(ga_path)
+    output_path = ga_path if output_path is None else Path(output_path)
+
+    with ga_path.open("r", encoding="utf-8") as f:
+        workflow = json.load(f)
+
+    steps = workflow.get("steps", {})
+    changed = []
+
+    for step_id, step in steps.items():
+        if step.get("type") in INPUT_STEP_TYPES and not step.get("label"):
+            label = f"input_{step_id}"
+            step["label"] = label
+            changed.append((step_id, label))
+
+    with output_path.open("w", encoding="utf-8") as f:
+        json.dump(workflow, f, indent=2)
+
+    print(f"Updated workflow with new input labels written to {output_path}")
+
+    
+def extract_error_message(exc: Exception) -> str:
+    if exc is None:
+        return "UNKNOWN_ERROR"
+
+    msg = str(exc).strip()
+    if msg:
+        return msg
+
+    return "".join(traceback.format_exception_only(type(exc), exc)).strip()
+
+
+def run_command(cmd: list[str], stage: str) -> subprocess.CompletedProcess:
+    result = subprocess.run(cmd, capture_output=True, text=True)
+    
+    if result.returncode != 0:
+        full_msg = (
+            f"{stage} failed with return code {result.returncode}\n"
+            f"STDOUT:\n{result.stdout}\n\nSTDERR:\n{result.stderr}"
+        )
+        raise RuntimeError(full_msg)
+
+    return result
+
+
+def testing_report(
+    output_galaxy_workflow_path: str,
+    knime_file: Path,
+    job_yml_path: Path,
+    input_image_path: Path,
+):
+    output_galaxy_workflow_path = Path(output_galaxy_workflow_path)
+    knime_file = Path(knime_file)
+    job_yml_path = Path(job_yml_path)
+    input_image_path = Path(input_image_path)
+
+    record = {
+        "file_name": knime_file.name,
+        "status": "success",
+        "failed_stage": None,
+        "error_raw": None,
+        "job_yml_path": str(job_yml_path),
+        "lint_stdout": None,
+        "lint_stderr": None,
+        "planemo_stdout": None,
+        "planemo_stderr": None,
+    }
+
+    stage = None
+
+    try:
+        output_galaxy_workflow_path = Path(output_galaxy_workflow_path)
+        output_galaxy_workflow_path_labeled = output_galaxy_workflow_path.with_name(f"{output_galaxy_workflow_path.stem}_labeled.ga")
+
+        stage = "workflow_lint"
+        lint_result = run_command(
+            [
+                "planemo",
+                "workflow_lint",
+                "--report_level", "error",
+                "--fail_level", "error",
+                str(output_galaxy_workflow_path),
+            ],
+            stage,
+        )
+
+        record["lint_stdout"] = lint_result.stdout
+        record["lint_stderr"] = lint_result.stderr
+
+        if lint_result.returncode != 0:
+            raise RuntimeError(
+                f"workflow_lint failed\n"
+                f"STDOUT:\n{lint_result.stdout}\n\n"
+                f"STDERR:\n{lint_result.stderr}"
+            )
+
+        stage = "label_ga"
+        add_missing_input_labels(
+            output_galaxy_workflow_path,
+            output_galaxy_workflow_path_labeled,
+        )
+
+        if not Path(output_galaxy_workflow_path_labeled).exists():
+            raise RuntimeError(
+                f"Labeled workflow was not created: "
+                f"{output_galaxy_workflow_path_labeled}"
+            )
+
+        stage = "generate_job_yml"
+        if not input_image_path.exists():
+            raise FileNotFoundError(
+                f"Input image does not exist: {input_image_path}"
+            )
+
+        generate_job_yaml(
+            output_galaxy_workflow_path_labeled,
+            job_yml_path,
+            input_image_path,
+        )
+
+        stage = "planemo_run"
+        if "GALAXY_API_KEY" not in os.environ:
+            raise RuntimeError(
+                "Environment variable GALAXY_API_KEY is not set"
+            )
+
+        cmd = [
+            "planemo",
+            "run",
+            str(output_galaxy_workflow_path_labeled),
+            str(job_yml_path),
+            "--engine", "external_galaxy",
+            "--galaxy_url", "https://usegalaxy.eu",
+            "--galaxy_user_key", os.environ["GALAXY_API_KEY"],
+        ]
+
+        planemo_result = run_command(cmd, stage)
+
+        record["planemo_stdout"] = planemo_result.stdout
+        record["planemo_stderr"] = planemo_result.stderr
+
+    except Exception as e:
+        record["status"] = "failed"
+        record["failed_stage"] = stage
+        record["error_raw"] = str(e)
+
+    return record

--- a/src/imaging_knime_to_galaxy/prompts.py
+++ b/src/imaging_knime_to_galaxy/prompts.py
@@ -129,16 +129,19 @@ The input node descriptions could be one of the following:
 
 # Output Requirements
 - Respond with the complete Galaxy workflow JSON object ONLY (no markdown fences, no comments, no explanations).
+- Name the workflow according to the contents of what it is doing
 - The JSON must be a valid Galaxy .ga workflow 
 - Make sure that it is a valid JSON object.
 - For uuid fields, write 00000000-0000-0000-0000-000000000000 as placeholder
 - Do not include TODOs or comments in the JSON.
 - Do not add anything in there that is not part of the Galaxy workflow JSON format
 - Get the tool ids, content ids and versions correct based on the following knowledge base of Galaxy tools:
+- Name the workflow according its contents
 
 {hits}
 
-NEVER come up with own tool IDs, content IDs or versions on your own. ONLY use the ones provided from the previously given knowledge base.
+NEVER come up with own tool names, tool IDs, content IDs or versions on your own. ONLY use the ones provided from the previously given knowledge base.
+If tools are invented, that are not existent, the whole workflow will fail. So it is very important to only use existent ones.
 
 - Use type: "data_input" only for a single dataset that is consumed by inputs expecting a single dataset.
 - Use type: "data_collection_input" only when any downstream input expects a collection (e.g., list or list:paired).
@@ -153,3 +156,59 @@ NEVER come up with own tool IDs, content IDs or versions on your own. ONLY use t
 """
     
     return task_prompt
+
+
+def build_report_prompt(
+    record: dict,
+    knwf_path: str,
+    output_galaxy_workflow_path: str,
+    knime_description: str,
+    knime_workflow_content: str,
+    ga_content: str,
+    hits: list,
+):
+
+    report_prompt = f"""
+You are an expert in writing reports about translation pipelines.
+
+You will receive a record that was produced about a translation process, in which a KNIME workflow file (.knwf) was translated into a Galaxy workflow file (.ga).
+The goal is to summarize what went wrong, if any errors occurred during testing or validation, based primarily on this record: {record}.
+
+The original .knwf workflow content can be seen here: {knime_workflow_content}
+The generated .ga workflow content can be seen here: {ga_content}
+
+Use the KNIME and Galaxy workflow contents only to explain why the observed failures occurred and whether the generated workflow correctly represents the original workflow.
+
+It is important to identify and explain any issues that prevent the generated .ga workflow from functioning correctly. Examples of issues to highlight include:
+- tools that are not working correctly for their intended purpose
+- hallucinated Galaxy tools (i.e., tools referenced in the .ga file that do not exist on the target Galaxy server)
+- formatting or structural issues in the generated .ga file
+- incorrect tool mappings between KNIME and Galaxy
+- missing workflow components or connections
+- parameter configuration errors
+
+Do not speculate about failures that are not supported by the provided record, KNIME workflow, or Galaxy workflow. If information is missing, explicitly state that the cause could not be determined from the available data.
+
+The report MUST be valid markdown (.md) and MUST have the following structure:
+
+# Knime2Galaxy Translation Report
+
+## Files
+- **KNIME Workflow file**: *{knwf_path}*
+- **Galaxy Output file**: *{output_galaxy_workflow_path}*
+
+## Successful Steps
+< IN BULLET POINTS: describe components that were translated correctly, tools that exist on the target Galaxy server, workflow sections that execute successfully, or workflow structures that correctly correspond to the original KNIME workflow. If no successful steps can be identified, explicitly state this. >
+
+## Recommended Tools
+< Go through this tools: {hits} and give a ONE SENTENCE explanation whether these tools are suitbale for the desired workflow or not> 
+
+## Failures
+< IN BULLET POINTS: describe what is not yet working, why the workflow is failing or producing errors, which tools are hallucinated / not installed / incorrectly configured, and any structural or formatting issues. Keep the explanation easy for the user to understand. If no failures are detected, explicitly state this. >
+
+## Recommendation
+< For each failure listed above, provide a corresponding corrective action. Clearly explain what the user needs to change in the .ga workflow to make it valid and better aligned with the original .knwf workflow. When possible, specify which tool, parameter, connection, or workflow element should be corrected or replaced. >
+
+Don't output anything other than the Markdown structure above.
+"""
+    return report_prompt

--- a/src/imaging_knime_to_galaxy/translate.py
+++ b/src/imaging_knime_to_galaxy/translate.py
@@ -3,9 +3,11 @@ from imaging_knime_to_galaxy.knime_io import load_tools_metadata, collect_knime_
 from imaging_knime_to_galaxy.Vectorstore import VectorStore
 from imaging_knime_to_galaxy.rag_functions import build_all_docs, embed, search_store_for_hits, EMBEDDING_MODEL
 from imaging_knime_to_galaxy.examples import build_translation_examples, build_workflow_examples
-from imaging_knime_to_galaxy.prompts import build_summary_prompt, build_description_task_prompt, build_task_prompt
+from imaging_knime_to_galaxy.prompts import build_summary_prompt, build_description_task_prompt, build_task_prompt, build_report_prompt
+from imaging_knime_to_galaxy.evaluation_functions import add_missing_input_labels, generate_job_yaml, run_command, testing_report, extract_error_message
 import os
 from huggingface_hub import hf_hub_download
+from pathlib import Path
 
 
 def translate_knime_to_galaxy(
@@ -16,6 +18,8 @@ def translate_knime_to_galaxy(
         output_galaxy_workflow_path: str,
         input_workflow_path: str,
         vector_store_path: str,
+        example_image_path="../knime2galaxy_scheme.png",
+
 ):
     meta_data = load_tools_metadata(tools_metadata_path)
     texts, metas = build_all_docs(meta_data)
@@ -82,3 +86,13 @@ def translate_knime_to_galaxy(
     replace_uuid(json_object)
     save_answer_to_file(json_object, output_path=output_galaxy_workflow_path)
     print(f"Saved .ga file to {output_galaxy_workflow_path}.")
+
+    print("Evaluating result and generating report ...")
+    record_dict = testing_report(output_galaxy_workflow_path, knwf_path, "job.yml", example_image_path)
+    report_prompt = build_report_prompt(record_dict, knwf_path, output_galaxy_workflow_path, description, workflow_content, answer, hits)
+    report = prompt_scadsai_llm(message= report_prompt)
+    output_path = Path(output_galaxy_workflow_path)
+    report_path = output_path.parent / f"report_{output_path.stem}.md"
+    with open(report_path, "w", encoding="utf-8") as f:
+        f.write(report)
+    print(f"Report saved under {report_path}.")

--- a/src/testing_pipeline.py
+++ b/src/testing_pipeline.py
@@ -3,152 +3,15 @@ import traceback
 import re
 import pandas as pd
 from imaging_knime_to_galaxy.translate import translate_knime_to_galaxy
+from imaging_knime_to_galaxy.evaluation_functions import add_missing_input_labels, generate_job_yaml, run_command, testing_report, extract_error_message
 import subprocess
 import os
 import json
 import yaml
 
 DATA_FOLDER = Path("../data").resolve()
-KNIME_FOLDER = DATA_FOLDER / "train_data_workflows" / "KNIME_2"
-OUTPUT_FOLDER = DATA_FOLDER / "output_file_test"
-OUTPUT_FOLDER.mkdir(parents=True, exist_ok=True)
-
 N_RUNS = 1
-INPUT_STEP_TYPES = {"data_input", "data_collection_input", "parameter_input"}
-
-JOB_YML = DATA_FOLDER / "job.yml"
-IMAGE = DATA_FOLDER / "image_ex.jpg"
-
-
-def generate_job_yaml(ga_path, output_path, default_file):
-    ga_path = Path(ga_path)
-    output_path = Path(output_path)
-    default_file = str(Path(default_file).resolve())
-
-    with ga_path.open("r", encoding="utf-8") as f:
-        workflow = json.load(f)
-
-    job = {}
-    for step_id, step in workflow.get("steps", {}).items():
-        if step.get("type") in INPUT_STEP_TYPES:
-            key = step.get("label") or f"input_{step_id}"
-            job[key] = {
-                "class": "File",
-                "path": default_file,
-            }
-
-    if not job:
-        raise ValueError(f"No workflow inputs found in {ga_path}")
-
-    with output_path.open("w", encoding="utf-8") as f:
-        yaml.safe_dump(job, f, sort_keys=False)
-
-    print(f"job.yml written to {output_path}")
-    print(yaml.safe_dump(job, sort_keys=False))
-
-
-def add_missing_input_labels(ga_path: str | Path, output_path: str | Path | None = None):
-    ga_path = Path(ga_path)
-    output_path = ga_path if output_path is None else Path(output_path)
-
-    with ga_path.open("r", encoding="utf-8") as f:
-        workflow = json.load(f)
-
-    steps = workflow.get("steps", {})
-    changed = []
-
-    for step_id, step in steps.items():
-        if step.get("type") in INPUT_STEP_TYPES and not step.get("label"):
-            label = f"input_{step_id}"
-            step["label"] = label
-            changed.append((step_id, label))
-
-    with output_path.open("w", encoding="utf-8") as f:
-        json.dump(workflow, f, indent=2)
-
-    print(f"Patched workflow written to {output_path}")
-    if changed:
-        print("Added labels:")
-        for step_id, label in changed:
-            print(f"  step {step_id} -> {label}")
-    else:
-        print("No missing input labels found.")
-
-
-def normalize_error_message(msg: str) -> str:
-    if not msg:
-        return "UNKNOWN_ERROR"
-
-    msg = msg.strip()
-
-    patterns = [
-        (
-            r"Workflow cannot be run because input step '.*?' \(.*?\) is not optional and no input provided\.",
-            "Missing required workflow input",
-        ),
-        (
-            r"No content id could be located for step .*",
-            "Missing content_id/tool_id",
-        ),
-        (
-            r"File \[.*\] does not exist.*",
-            "Input file does not exist",
-        ),
-        (
-            r"Parameter '.*?': specify a dataset of the required format / build for parameter",
-            "Wrong dataset format for tool parameter",
-        ),
-        (
-            r"No value found for '.*?'\. Using default:",
-            "Missing tool parameter value",
-        ),
-        (
-            r"Java heap space",
-            "KNIME out of memory",
-        ),
-        (
-            r"Node can't be executed - Node .* not available from extension .*",
-            "Missing KNIME extension",
-        ),
-        (
-            r"There were problems with \d+ test\(s\)",
-            "Planemo run/test reported workflow failures",
-        ),
-        (
-            r"Run failed \[.*\]",
-            "Planemo run failed",
-        ),
-    ]
-
-    for pattern, label in patterns:
-        if re.search(pattern, msg, flags=re.DOTALL):
-            return label
-
-    return msg.splitlines()[0][:300]
-
-
-def extract_error_message(exc: Exception) -> str:
-    if exc is None:
-        return "UNKNOWN_ERROR"
-
-    msg = str(exc).strip()
-    if msg:
-        return msg
-
-    return "".join(traceback.format_exception_only(type(exc), exc)).strip()
-
-
-def run_command(cmd: list[str], stage: str) -> subprocess.CompletedProcess:
-    result = subprocess.run(cmd, capture_output=True, text=True)
-    
-    if result.returncode != 0:
-        full_msg = (
-            f"{stage} failed with return code {result.returncode}\n"
-            f"STDOUT:\n{result.stdout}\n\nSTDERR:\n{result.stderr}"
-        )
-        raise RuntimeError(full_msg)
-
-    return result
+KNIME_FOLDER = DATA_FOLDER / "train_data_workflows" / "KNIME_2"
 
 
 def run_single_pipeline(knime_file: Path, run_idx: int) -> dict:
@@ -159,7 +22,6 @@ def run_single_pipeline(knime_file: Path, run_idx: int) -> dict:
         "status": "success",
         "failed_stage": None,
         "error_raw": None,
-        "error_normalized": None,
         "ga_path": None,
         "ga_labeled_path": None,
         "job_yml_path": str(JOB_YML),
@@ -252,9 +114,8 @@ def run_single_pipeline(knime_file: Path, run_idx: int) -> dict:
         record["status"] = "failed"
         record["failed_stage"] = stage
         record["error_raw"] = raw_error
-        record["error_normalized"] = normalize_error_message(raw_error)
         return record
-
+        
 
 def run_batch(knime_folder: Path, n_runs: int) -> pd.DataFrame:
     results = []
@@ -272,7 +133,6 @@ def run_batch(knime_folder: Path, n_runs: int) -> pd.DataFrame:
             print(f"Planemo Result: {result['planemo_stdout']}")
             if result["status"] == "failed":
                 print(f"Failed stage: {result['failed_stage']}")
-                print(f"Error bucket: {result['error_normalized']}")
 
     return pd.DataFrame(results)
 
@@ -280,28 +140,21 @@ def run_batch(knime_folder: Path, n_runs: int) -> pd.DataFrame:
 def summarize_errors(df: pd.DataFrame):
     failed = df[df["status"] == "failed"].copy()
 
-    error_counts = (
-        failed["error_normalized"]
-        .value_counts(dropna=False)
-        .rename_axis("error_type")
-        .reset_index(name="count")
-    )
-
     stage_error_counts = (
-        failed.groupby(["failed_stage", "error_normalized"])
+        failed.groupby(["failed_stage"])
         .size()
         .reset_index(name="count")
         .sort_values(["failed_stage", "count"], ascending=[True, False])
     )
 
     file_error_counts = (
-        failed.groupby(["file_name", "error_normalized"])
+        failed.groupby(["file_name"])
         .size()
         .reset_index(name="count")
         .sort_values(["file_name", "count"], ascending=[True, False])
     )
 
-    return error_counts, stage_error_counts, file_error_counts
+    return stage_error_counts, file_error_counts
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
**Report Logic changes:**
- some functions of _testing_pipeline.py_ are moved to another src script called _evaluation_functions.py_ ( because they are needed for the reporting logic as well)
- a few lines of code are added to the  _translate_knime_to_galaxy_ function in _translate.py_ to get the report generated and saved
- new new prompt is added to _prompts.py_ which is generating the reporting prompt

Additional changes:
- _demo notebook_: generated output .ga file has a more generic name now